### PR TITLE
Rename `LowerCaseModel` to `FlatCaseModel`, as the naming convention is correctly called flat case

### DIFF
--- a/src/pythonxbox/api/provider/userstats/models.py
+++ b/src/pythonxbox/api/provider/userstats/models.py
@@ -1,4 +1,4 @@
-from pythonxbox.common.models import LowerCaseModel, PascalCaseModel
+from pythonxbox.common.models import FlatCaseModel, PascalCaseModel
 
 
 class GeneralStatsField:
@@ -17,7 +17,7 @@ class Properties(PascalCaseModel):
     display_name: str | None = None
 
 
-class Stat(LowerCaseModel):
+class Stat(FlatCaseModel):
     group_properties: GroupProperties | None = None
     xuid: str
     scid: str
@@ -27,18 +27,18 @@ class Stat(LowerCaseModel):
     properties: Properties
 
 
-class StatListsCollectionItem(LowerCaseModel):
+class StatListsCollectionItem(FlatCaseModel):
     arrange_by_field: str
     arrange_by_field_id: str
     stats: list[Stat]
 
 
-class Group(LowerCaseModel):
+class Group(FlatCaseModel):
     name: str
     title_id: str | None = None
     statlistscollection: list[StatListsCollectionItem]
 
 
-class UserStatsResponse(LowerCaseModel):
+class UserStatsResponse(FlatCaseModel):
     groups: list[Group] | None = None
     statlistscollection: list[StatListsCollectionItem]

--- a/src/pythonxbox/common/models.py
+++ b/src/pythonxbox/common/models.py
@@ -4,8 +4,8 @@ from pydantic import BaseModel, ConfigDict
 from pydantic.alias_generators import to_camel, to_pascal
 
 
-def to_lower(string: str) -> str:
-    return string.replace("_", "")
+def to_flat(string: str) -> str:
+    return string.lower().replace("_", "")
 
 
 class PascalCaseModel(BaseModel):
@@ -20,7 +20,7 @@ class CamelCaseModel(BaseModel):
     )
 
 
-class LowerCaseModel(BaseModel):
+class FlatCaseModel(BaseModel):
     model_config = ConfigDict(
-        arbitrary_types_allowed=True, populate_by_name=True, alias_generator=to_lower
+        arbitrary_types_allowed=True, populate_by_name=True, alias_generator=to_flat
     )


### PR DESCRIPTION
helper function `to_lower` is also renamed to `to_flat` 